### PR TITLE
Add Claude export support (closes #13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ uv run ricoeur init
 # Import your ChatGPT export
 uv run ricoeur import chatgpt ~/Downloads/chatgpt-export/conversations.json
 
+# ...or your Claude export (Settings > Privacy > Export data)
+uv run ricoeur import claude ~/Downloads/claude-export/conversations.json
+
 # Build the intelligence layer (language detection, embeddings, analytics)
 uv run ricoeur index
 
@@ -32,6 +35,7 @@ uv run ricoeur search "thermal simulation"
 |---------|-------------|
 | `ricoeur init` | Initialize database and config at `~/.ricoeur/` |
 | `ricoeur import chatgpt <path>` | Import from ChatGPT export (.json or .zip) |
+| `ricoeur import claude <path>` | Import from Claude export (.json or .zip) |
 | `ricoeur search <query>` | Search across all conversations (hybrid by default) |
 | `ricoeur show <id>` | Display a conversation with formatting |
 | `ricoeur stats` | Analytics dashboard |
@@ -141,9 +145,16 @@ ricoeur import chatgpt conversations.json --dry-run
 
 # Only import recent conversations
 ricoeur import chatgpt conversations.json --since 2025-01-01
+
+# The same flags work for Claude exports
+ricoeur import claude conversations.json --update
 ```
 
-> **Coming soon:** Claude, Gemini, and custom JSON imports.
+ChatGPT and Claude exports are both supported. Each platform ships a
+`conversations.json` (sometimes inside a `.zip`) — point ricoeur at either the
+JSON file or the zip and it will find the conversations.
+
+> **Coming soon:** Gemini and custom JSON imports.
 
 ## Optional extras
 

--- a/src/ricoeur/importers/claude.py
+++ b/src/ricoeur/importers/claude.py
@@ -134,10 +134,16 @@ def _import_one(
 
 
 def _extract_content(msg: dict[str, Any]) -> str:
-    """Extract text from a Claude message."""
+    """Extract text from a Claude message.
+
+    Claude's export gives each message a flattened, human-readable ``text``
+    field that already concatenates the visible response and (expanded)
+    thinking while omitting tool-call noise. Prefer it; fall back to
+    reconstructing from the structured ``content`` blocks when it is absent.
+    """
     # Claude messages can have "text" directly or "content" as a list of blocks
     text = msg.get("text")
-    if text:
+    if text and text.strip():
         return text
 
     content = msg.get("content", "")
@@ -150,8 +156,12 @@ def _extract_content(msg: dict[str, Any]) -> str:
             if isinstance(block, str):
                 parts.append(block)
             elif isinstance(block, dict):
-                if block.get("type") == "text":
+                btype = block.get("type")
+                if btype == "text":
                     parts.append(block.get("text", ""))
-        return "\n".join(parts)
+                elif btype == "thinking":
+                    parts.append(block.get("thinking", ""))
+                # tool_use / tool_result blocks are interface noise — skip them
+        return "\n".join(p for p in parts if p)
 
     return ""

--- a/tests/test_claude_importer.py
+++ b/tests/test_claude_importer.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import sqlite3
 import zipfile
-from pathlib import Path
 
 import pytest
 

--- a/tests/test_claude_importer.py
+++ b/tests/test_claude_importer.py
@@ -1,0 +1,289 @@
+"""Tests for the Claude conversation importer."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from ricoeur.db import SCHEMA_SQL
+from ricoeur.importers.claude import import_claude, _extract_content
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def conn():
+    """In-memory SQLite database with the ricoeur schema."""
+    c = sqlite3.connect(":memory:")
+    c.row_factory = sqlite3.Row
+    c.executescript(SCHEMA_SQL)
+    return c
+
+
+def _conv(uuid, name, messages, **extra):
+    """Build a Claude-export-shaped conversation dict."""
+    return {
+        "uuid": uuid,
+        "name": name,
+        "summary": "",
+        "created_at": "2025-10-23T01:18:38.477062Z",
+        "updated_at": "2025-10-23T01:18:45.100465Z",
+        "account": {"uuid": "acct-1"},
+        "chat_messages": messages,
+        **extra,
+    }
+
+
+def _msg(uuid, sender, text=None, content=None, **extra):
+    m = {
+        "uuid": uuid,
+        "sender": sender,
+        "created_at": "2025-10-23T01:18:39.446848Z",
+        "updated_at": "2025-10-23T01:18:39.446848Z",
+        "attachments": [],
+        "files": [],
+        "parent_message_uuid": "00000000-0000-4000-8000-000000000000",
+        **extra,
+    }
+    if text is not None:
+        m["text"] = text
+    if content is not None:
+        m["content"] = content
+    return m
+
+
+@pytest.fixture
+def sample_export():
+    return [
+        _conv(
+            "conv-a",
+            "Magic number calculation",
+            [
+                _msg("m1", "human", text="compute magic of 5"),
+                _msg(
+                    "m2",
+                    "assistant",
+                    text="The magic constant of a 5x5 square is 65.\n```python\nprint(65)\n```",
+                ),
+            ],
+        ),
+        _conv(
+            "conv-b",
+            "Strawberry letters",
+            [
+                _msg("m3", "human", text="count r in strawberry"),
+                _msg("m4", "assistant", text="There are 3 r's."),
+            ],
+        ),
+    ]
+
+
+# ── Basic import ─────────────────────────────────────────────────────────
+
+
+def test_import_from_file(conn, sample_export, tmp_path):
+    p = tmp_path / "conversations.json"
+    p.write_text(json.dumps(sample_export))
+
+    stats = import_claude(conn, p)
+
+    assert stats.parsed == 2
+    assert stats.new == 2
+    assert stats.skipped == 0
+    assert stats.messages == 4
+
+    convs = conn.execute(
+        "SELECT id, title, platform, model FROM conversations ORDER BY id"
+    ).fetchall()
+    assert [r["id"] for r in convs] == ["conv-a", "conv-b"]
+    assert all(r["platform"] == "claude" for r in convs)
+    # Claude exports carry no model field
+    assert all(r["model"] is None for r in convs)
+
+
+def test_role_normalization(conn, sample_export, tmp_path):
+    p = tmp_path / "conversations.json"
+    p.write_text(json.dumps(sample_export))
+    import_claude(conn, p)
+
+    roles = {
+        r["role"]
+        for r in conn.execute("SELECT DISTINCT role FROM messages").fetchall()
+    }
+    # "human" must be normalized to "user"; no raw "human" left
+    assert roles == {"user", "assistant"}
+
+
+def test_message_count_updated(conn, sample_export, tmp_path):
+    p = tmp_path / "conversations.json"
+    p.write_text(json.dumps(sample_export))
+    import_claude(conn, p)
+
+    row = conn.execute(
+        "SELECT message_count FROM conversations WHERE id = 'conv-a'"
+    ).fetchone()
+    assert row["message_count"] == 2
+
+
+def test_code_blocks_extracted(conn, sample_export, tmp_path):
+    p = tmp_path / "conversations.json"
+    p.write_text(json.dumps(sample_export))
+    import_claude(conn, p)
+
+    blocks = conn.execute(
+        "SELECT language, code FROM code_blocks"
+    ).fetchall()
+    assert len(blocks) == 1
+    assert blocks[0]["language"] == "python"
+    assert "print(65)" in blocks[0]["code"]
+
+
+def test_timestamps_preserved(conn, sample_export, tmp_path):
+    p = tmp_path / "conversations.json"
+    p.write_text(json.dumps(sample_export))
+    import_claude(conn, p)
+
+    # Claude timestamps are already ISO strings — stored as-is
+    row = conn.execute(
+        "SELECT created_at FROM conversations WHERE id = 'conv-a'"
+    ).fetchone()
+    assert row["created_at"] == "2025-10-23T01:18:38.477062Z"
+
+
+# ── Options ──────────────────────────────────────────────────────────────
+
+
+def test_dry_run_writes_nothing(conn, sample_export, tmp_path):
+    p = tmp_path / "conversations.json"
+    p.write_text(json.dumps(sample_export))
+    stats = import_claude(conn, p, dry_run=True)
+
+    assert stats.new == 2
+    assert conn.execute("SELECT COUNT(*) n FROM conversations").fetchone()["n"] == 0
+    assert conn.execute("SELECT COUNT(*) n FROM messages").fetchone()["n"] == 0
+
+
+def test_since_filter(conn, sample_export, tmp_path):
+    # First conversation is dated 2025-10-23; filter past it
+    p = tmp_path / "conversations.json"
+    p.write_text(json.dumps(sample_export))
+    stats = import_claude(conn, p, since="2026-01-01")
+
+    assert stats.new == 0
+    assert stats.skipped == 2
+
+
+def test_reimport_skips_without_update(conn, sample_export, tmp_path):
+    p = tmp_path / "conversations.json"
+    p.write_text(json.dumps(sample_export))
+    import_claude(conn, p)
+    stats = import_claude(conn, p)  # second pass
+
+    assert stats.new == 0
+    assert stats.skipped == 2
+    assert conn.execute("SELECT COUNT(*) n FROM conversations").fetchone()["n"] == 2
+
+
+def test_update_flag_refreshes_title(conn, sample_export, tmp_path):
+    p = tmp_path / "conversations.json"
+    p.write_text(json.dumps(sample_export))
+    import_claude(conn, p)
+
+    sample_export[0]["name"] = "Renamed conversation"
+    p.write_text(json.dumps(sample_export))
+    stats = import_claude(conn, p, update=True)
+
+    assert stats.new == 2  # update counts as inserted in stats
+    title = conn.execute(
+        "SELECT title FROM conversations WHERE id = 'conv-a'"
+    ).fetchone()["title"]
+    assert title == "Renamed conversation"
+
+
+def test_load_from_zip(conn, sample_export, tmp_path):
+    zip_path = tmp_path / "claude-export.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("conversations.json", json.dumps(sample_export))
+
+    stats = import_claude(conn, zip_path)
+    assert stats.new == 2
+
+
+def test_non_list_raises(conn, tmp_path):
+    p = tmp_path / "conversations.json"
+    p.write_text(json.dumps({"not": "a list"}))
+    with pytest.raises(ValueError, match="array of conversations"):
+        import_claude(conn, p)
+
+
+# ── Content extraction ─────────────────────────────────────────────────────
+
+
+def test_extract_content_prefers_text_field():
+    msg = {"text": "hello", "content": [{"type": "text", "text": "ignored"}]}
+    assert _extract_content(msg) == "hello"
+
+
+def test_extract_content_falls_back_to_blocks():
+    # Empty top-level text → reconstruct from content blocks
+    msg = {
+        "text": "   ",
+        "content": [
+            {"type": "thinking", "thinking": "reasoning here"},
+            {"type": "tool_use", "name": "web_search"},
+            {"type": "tool_result", "content": "noise"},
+            {"type": "text", "text": "the answer"},
+        ],
+    }
+    out = _extract_content(msg)
+    assert "the answer" in out
+    assert "reasoning here" in out
+    # tool noise excluded
+    assert "web_search" not in out
+    assert "noise" not in out
+
+
+def test_extract_content_string_content():
+    assert _extract_content({"content": "plain string"}) == "plain string"
+
+
+def test_extract_content_empty():
+    assert _extract_content({"content": []}) == ""
+    assert _extract_content({}) == ""
+
+
+def test_pure_tool_message_skipped(conn, tmp_path):
+    """A message with no visible text (only tool/thinking-less blocks) is skipped."""
+    export = [
+        _conv(
+            "conv-c",
+            "Tool only",
+            [
+                _msg("m5", "human", text="do something"),
+                _msg(
+                    "m6",
+                    "assistant",
+                    text="",
+                    content=[
+                        {"type": "tool_use", "name": "bash"},
+                        {"type": "tool_result", "content": "result"},
+                    ],
+                ),
+            ],
+        )
+    ]
+    p = tmp_path / "conversations.json"
+    p.write_text(json.dumps(export))
+    stats = import_claude(conn, p)
+
+    # Only the human message has content
+    assert stats.messages == 1
+    roles = [
+        r["role"] for r in conn.execute("SELECT role FROM messages").fetchall()
+    ]
+    assert roles == ["user"]

--- a/website/index.html
+++ b/website/index.html
@@ -678,8 +678,8 @@
           <div class="feature-icon terra">
             <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
           </div>
-          <h3>Multi-Platform <span class="badge-soon">Coming soon</span></h3>
-          <p>Import from ChatGPT today. Claude, Gemini, and custom JSON imports coming soon.</p>
+          <h3>Multi-Platform</h3>
+          <p>Import from ChatGPT and Claude today. Gemini and custom JSON imports coming soon.</p>
         </div>
         <div class="feature-card reveal">
           <div class="feature-icon emerald">


### PR DESCRIPTION
## Summary

Finishes Claude `conversations.json` import support requested in #13. A `claude.py` importer and `ricoeur import claude` command already existed but were undocumented, untested, and had a content-extraction gap — this PR closes those out.

## Changes

- **`src/ricoeur/importers/claude.py`** — Harden `_extract_content`: fall back to reconstructing from `content` blocks when the top-level `text` is empty/whitespace, include `thinking` blocks, and explicitly skip `tool_use`/`tool_result` interface noise (matches Claude's own flattened `text` rendering).
- **`tests/test_claude_importer.py`** (new) — 16 tests: basic import, `human`→`user` role normalization, message counts, code-block extraction, timestamp preservation, `--dry-run`, `--since`, re-import skip/`--update`, `.zip` loading, non-list validation, and content-extraction edge cases.
- **`README.md`** + **`website/index.html`** — Document Claude as supported (quickstart, commands table, import options); remove the "coming soon" badge.

## Verification

- Imported a real 397-conversation Claude export → **397 conversations, 1,561 messages, 2,255 code blocks**, with role normalization and ISO timestamps preserved.
- Full test suite: **47 passed** (31 existing + 16 new).

## Notes

- Claude's export contains **no model field**, so `model` is stored as `NULL` (shows "unknown" in `stats`) — a format limitation, not a bug.
- The per-conversation `summary` field is not imported (summaries come from `ricoeur index --summarize`); left out to keep scope tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)