### PR TITLE
Add interactive terminal UI (ricoeur tui)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ uv run ricoeur search "thermal simulation"
 | `ricoeur search <query>` | Search across all conversations (hybrid by default) |
 | `ricoeur show <id>` | Display a conversation with formatting |
 | `ricoeur stats` | Analytics dashboard |
+| `ricoeur tui` | Interactive terminal UI to browse and search |
 | `ricoeur index` | Build intelligence layer (languages, embeddings, analytics) |
 | `ricoeur config show` | Print current configuration |
 | `ricoeur config set <key> <value>` | Update a config value |
@@ -97,6 +98,30 @@ Found 20 results for "how to containerize applications" (semantic)
 ```
 
 Keyword found 3 results matching the literal words. Semantic found 20 — including Docker, Wasm, and container deployment conversations that never mention "containerize applications".
+
+## Terminal UI
+
+Prefer browsing interactively? Launch the TUI:
+
+```bash
+# Install the optional dependency
+uv sync --extra tui
+
+# Launch
+uv run ricoeur tui
+```
+
+It opens to your most recent conversations. Type a query and press **Enter** to
+keyword-search; clear the box and press Enter to return to the recent list.
+Select a row (Enter) to read the full conversation, rendered as Markdown.
+
+| Key | Action |
+|-----|--------|
+| `/` | Focus the search box |
+| `Enter` | Search (in box) / open conversation (in list) |
+| `↑` `↓` `j` `k` | Move / scroll |
+| `Esc` | Back to the list |
+| `q` | Quit |
 
 ## Index
 
@@ -173,7 +198,7 @@ uv sync --extra topics
 # Analytics with DuckDB + Parquet
 uv sync --extra analytics
 
-# Terminal UI (coming soon)
+# Terminal UI
 uv sync --extra tui
 
 # MCP server for Claude Desktop (coming soon)

--- a/src/ricoeur/cli.py
+++ b/src/ricoeur/cli.py
@@ -525,6 +525,30 @@ def config_set(key: str, value: str):
         console.print(f"[red]Error:[/red] {e}")
 
 
+# ── tui ──────────────────────────────────────────────────────────────────
+
+
+@cli.command()
+def tui():
+    """Launch the interactive terminal UI to browse and search conversations."""
+    from .db import db_path
+
+    home = get_home()
+    if not db_path(home).exists():
+        console.print(
+            "[red]No database found.[/red] Run [bold]ricoeur init[/bold] and import "
+            "a conversation export first."
+        )
+        raise SystemExit(1)
+
+    try:
+        from .tui import run as run_tui
+    except ModuleNotFoundError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise SystemExit(1)
+    run_tui(home)
+
+
 # ── version ──────────────────────────────────────────────────────────────
 
 

--- a/src/ricoeur/tui.py
+++ b/src/ricoeur/tui.py
@@ -1,0 +1,273 @@
+"""Terminal UI for ricoeur, built with Textual.
+
+Browse, search, and read your conversation archive interactively. The TUI is a
+thin shell over the same data layer the CLI uses (``db`` + ``search``), so it
+needs no extra state of its own.
+
+Launch with ``ricoeur tui`` (requires ``pip install 'ricoeur[tui]'``).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Optional
+
+from .config import get_home, load_config
+from .db import get_connection
+from .search import search_dispatch
+
+try:
+    from rich.markdown import Markdown as RichMarkdown
+    from textual import on
+    from textual.app import App, ComposeResult
+    from textual.binding import Binding
+    from textual.containers import VerticalScroll
+    from textual.screen import Screen
+    from textual.widgets import (
+        DataTable,
+        Footer,
+        Header,
+        Input,
+        Static,
+    )
+except ModuleNotFoundError as exc:  # pragma: no cover - exercised via CLI
+    raise ModuleNotFoundError(
+        "The TUI requires the 'textual' package. Install it with: "
+        "pip install 'ricoeur[tui]'  (or: uv sync --extra tui)"
+    ) from exc
+
+
+# ── Data helpers ───────────────────────────────────────────────────────────
+
+
+def _recent_conversations(conn: sqlite3.Connection, limit: int = 50) -> list[sqlite3.Row]:
+    """Most recently created conversations — the default browse view."""
+    return conn.execute(
+        """SELECT id, title, platform, model, created_at, message_count
+           FROM conversations
+           ORDER BY created_at DESC
+           LIMIT ?""",
+        (limit,),
+    ).fetchall()
+
+
+def _conversation(conn: sqlite3.Connection, conv_id: str) -> Optional[sqlite3.Row]:
+    return conn.execute(
+        "SELECT * FROM conversations WHERE id = ?", (conv_id,)
+    ).fetchone()
+
+
+def _messages(conn: sqlite3.Connection, conv_id: str) -> list[sqlite3.Row]:
+    return conn.execute(
+        "SELECT role, content, timestamp FROM messages WHERE conv_id = ? ORDER BY timestamp",
+        (conv_id,),
+    ).fetchall()
+
+
+# ── Conversation detail screen ───────────────────────────────────────────────
+
+
+class ConversationScreen(Screen):
+    """Full read view of a single conversation, rendered as Markdown."""
+
+    BINDINGS = [
+        Binding("escape,backspace,q", "app.pop_screen", "Back"),
+        Binding("j,down", "scroll_down", "Down", show=False),
+        Binding("k,up", "scroll_up", "Up", show=False),
+    ]
+
+    def __init__(self, conn: sqlite3.Connection, conv_id: str) -> None:
+        super().__init__()
+        self._conn = conn
+        self._conv_id = conv_id
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        with VerticalScroll(id="conversation-body"):
+            yield Static(RichMarkdown(self._transcript()))
+        yield Footer()
+
+    def _transcript(self) -> str:
+        conv = _conversation(self._conn, self._conv_id)
+        if conv is None:
+            return "# Conversation not found"
+
+        date = (conv["created_at"] or "?")[:10]
+        meta = f"`{conv['platform']}`"
+        if conv["model"]:
+            meta += f" · `{conv['model']}`"
+        meta += f" · {date}"
+
+        lines = [f"# {conv['title'] or 'Untitled'}", "", meta, ""]
+        for msg in _messages(self._conn, self._conv_id):
+            who = "🧑 You" if msg["role"] == "user" else "🤖 Assistant"
+            ts = (msg["timestamp"] or "")[:16]
+            lines.append("---")
+            lines.append(f"### {who}  ·  {ts}")
+            lines.append("")
+            lines.append(msg["content"] or "*(empty)*")
+            lines.append("")
+        return "\n".join(lines)
+
+    def action_scroll_down(self) -> None:
+        self.query_one("#conversation-body", VerticalScroll).scroll_down()
+
+    def action_scroll_up(self) -> None:
+        self.query_one("#conversation-body", VerticalScroll).scroll_up()
+
+
+# ── Main search / browse screen ──────────────────────────────────────────────
+
+
+class RicoeurApp(App):
+    """Browse and search your conversation archive."""
+
+    TITLE = "ricoeur"
+    SUB_TITLE = "your conversation archive"
+
+    CSS = """
+    #search {
+        dock: top;
+        margin: 1 1 0 1;
+    }
+    #status {
+        dock: top;
+        height: 1;
+        padding: 0 2;
+        color: $text-muted;
+    }
+    DataTable {
+        height: 1fr;
+    }
+    #conversation-body {
+        padding: 1 2;
+    }
+    """
+
+    BINDINGS = [
+        Binding("q", "quit", "Quit"),
+        Binding("/", "focus_search", "Search"),
+        Binding("enter", "open_selected", "Open", show=False),
+    ]
+
+    def __init__(self, home: Optional[Path] = None) -> None:
+        super().__init__()
+        self._home = home or get_home()
+        self._conn = get_connection(self._home)
+        cfg = load_config()
+        embed_cfg = cfg.get("embeddings", {})
+        self._model_spec = embed_cfg.get("model", "")
+        self._device = embed_cfg.get("device", "auto")
+        # Maps the visible row index → conversation id
+        self._row_ids: list[str] = []
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield Input(placeholder="Search your conversations… (Enter to search, empty = recent)", id="search")
+        yield Static("", id="status")
+        table = DataTable(id="results", cursor_type="row", zebra_stripes=True)
+        table.add_columns("Date", "Platform", "Msgs", "Title")
+        yield table
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self._show_recent()
+
+    # ── Populating the table ──────────────────────────────────────────────
+
+    def _table(self) -> DataTable:
+        return self.query_one("#results", DataTable)
+
+    def _set_status(self, text: str) -> None:
+        self.query_one("#status", Static).update(text)
+
+    def _show_recent(self) -> None:
+        try:
+            rows = _recent_conversations(self._conn)
+            n = self._conn.execute("SELECT COUNT(*) AS n FROM conversations").fetchone()["n"]
+        except sqlite3.Error:
+            # Database exists but isn't initialized / has no schema yet
+            self._populate([], [])
+            self._set_status("No conversations yet — import an export with `ricoeur import`.")
+            return
+
+        self._populate(
+            [
+                ((r["created_at"] or "?")[:10], r["platform"], str(r["message_count"] or 0), r["title"] or "Untitled")
+                for r in rows
+            ],
+            [r["id"] for r in rows],
+        )
+        if n:
+            self._set_status(f"{n:,} conversations · showing {len(rows)} most recent")
+        else:
+            self._set_status("No conversations yet — import an export with `ricoeur import`.")
+
+    def _run_search(self, query: str) -> None:
+        try:
+            results, mode = search_dispatch(
+                self._conn,
+                query,
+                self._home,
+                keyword=True,  # keyword is instant and needs no embedding model
+                model_spec=self._model_spec,
+                device=self._device,
+                limit=100,
+            )
+        except (RuntimeError, sqlite3.Error) as exc:
+            self._set_status(f"[red]Search error:[/red] {exc}")
+            return
+
+        self._populate(
+            [
+                ((r.created_at or "?")[:10], r.platform, "", r.title or "Untitled")
+                for r in results
+            ],
+            [r.conv_id for r in results],
+        )
+        self._set_status(f'{len(results)} result(s) for "{query}" ({mode})')
+
+    def _populate(self, rows: list[tuple], ids: list[str]) -> None:
+        table = self._table()
+        table.clear()
+        self._row_ids = ids
+        for row in rows:
+            table.add_row(*row)
+        if rows:
+            table.focus()
+            table.move_cursor(row=0)
+
+    # ── Actions ───────────────────────────────────────────────────────────
+
+    def action_focus_search(self) -> None:
+        self.query_one("#search", Input).focus()
+
+    @on(Input.Submitted, "#search")
+    def _on_search_submitted(self, event: Input.Submitted) -> None:
+        query = event.value.strip()
+        if query:
+            self._run_search(query)
+        else:
+            self._show_recent()
+
+    @on(DataTable.RowSelected, "#results")
+    def _on_row_selected(self, event: DataTable.RowSelected) -> None:
+        self._open_row(event.cursor_row)
+
+    def action_open_selected(self) -> None:
+        table = self._table()
+        if table.has_focus:
+            self._open_row(table.cursor_row)
+
+    def _open_row(self, row_index: int) -> None:
+        if 0 <= row_index < len(self._row_ids):
+            self.push_screen(ConversationScreen(self._conn, self._row_ids[row_index]))
+
+    def on_unmount(self) -> None:
+        self._conn.close()
+
+
+def run(home: Optional[Path] = None) -> None:
+    """Launch the ricoeur TUI."""
+    RicoeurApp(home=home).run()

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,0 +1,147 @@
+"""Tests for the Textual TUI.
+
+These exercise the app headlessly via Textual's test pilot. Skipped entirely
+when the optional ``textual`` dependency isn't installed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+
+import pytest
+
+pytest.importorskip("textual")
+
+from ricoeur.db import SCHEMA_SQL  # noqa: E402
+from ricoeur.tui import RicoeurApp, ConversationScreen  # noqa: E402
+from textual.widgets import DataTable, Static  # noqa: E402
+
+
+@pytest.fixture
+def populated_home(tmp_path):
+    """A ricoeur home dir with a seeded database."""
+    db = tmp_path / "ricoeur.db"
+    conn = sqlite3.connect(str(db))
+    conn.executescript(SCHEMA_SQL)
+    conn.execute(
+        "INSERT INTO conversations (id, title, platform, model, created_at, message_count) "
+        "VALUES ('c1', 'MATLAB from Python', 'claude', NULL, '2025-10-26T10:00:00Z', 2)"
+    )
+    conn.execute(
+        "INSERT INTO conversations (id, title, platform, model, created_at, message_count) "
+        "VALUES ('c2', 'Docker basics', 'chatgpt', 'gpt-4o', '2025-09-01T10:00:00Z', 2)"
+    )
+    conn.executemany(
+        "INSERT INTO messages (id, conv_id, role, content, timestamp) VALUES (?,?,?,?,?)",
+        [
+            ("m1", "c1", "user", "how to call matlab from python", "2025-10-26T10:00:01Z"),
+            ("m2", "c1", "assistant", "Use the matlabengine package.", "2025-10-26T10:00:02Z"),
+            ("m3", "c2", "user", "what is docker", "2025-09-01T10:00:01Z"),
+            ("m4", "c2", "assistant", "Docker packages apps in containers.", "2025-09-01T10:00:02Z"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+    return tmp_path
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def test_mount_shows_recent(populated_home):
+    async def scenario():
+        app = RicoeurApp(home=populated_home)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            table = app.query_one("#results", DataTable)
+            # Both conversations show, most recent first
+            assert table.row_count == 2
+            assert app._row_ids[0] == "c1"
+            status = str(app.query_one("#status", Static).render())
+            assert "2 conversations" in status
+
+    _run(scenario())
+
+
+def test_keyword_search_filters(populated_home):
+    async def scenario():
+        app = RicoeurApp(home=populated_home)
+        async with app.run_test() as pilot:
+            search = app.query_one("#search")
+            search.focus()
+            search.value = "matlab"
+            await pilot.press("enter")
+            await pilot.pause()
+            table = app.query_one("#results", DataTable)
+            assert table.row_count == 1
+            assert app._row_ids == ["c1"]
+
+    _run(scenario())
+
+
+def test_no_match_clears_table(populated_home):
+    async def scenario():
+        app = RicoeurApp(home=populated_home)
+        async with app.run_test() as pilot:
+            search = app.query_one("#search")
+            search.focus()
+            search.value = "nonexistentterm"
+            await pilot.press("enter")
+            await pilot.pause()
+            assert app.query_one("#results", DataTable).row_count == 0
+            assert app._row_ids == []
+
+    _run(scenario())
+
+
+def test_empty_query_returns_to_recent(populated_home):
+    async def scenario():
+        app = RicoeurApp(home=populated_home)
+        async with app.run_test() as pilot:
+            search = app.query_one("#search")
+            search.focus()
+            search.value = "matlab"
+            await pilot.press("enter")
+            await pilot.pause()
+            # Searching moves focus to the results; refocus search to clear it
+            search.focus()
+            search.value = ""
+            await pilot.press("enter")
+            await pilot.pause()
+            assert app.query_one("#results", DataTable).row_count == 2
+
+    _run(scenario())
+
+
+def test_open_conversation_renders(populated_home):
+    async def scenario():
+        app = RicoeurApp(home=populated_home)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app._open_row(0)
+            await pilot.pause()
+            await pilot.pause()
+            assert isinstance(app.screen, ConversationScreen)
+            # Back out
+            await pilot.press("escape")
+            await pilot.pause()
+            assert not isinstance(app.screen, ConversationScreen)
+
+    _run(scenario())
+
+
+def test_transcript_includes_messages(populated_home):
+    """The detail screen's transcript carries the conversation's messages."""
+    async def scenario():
+        app = RicoeurApp(home=populated_home)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            screen = ConversationScreen(app._conn, "c1")
+            text = screen._transcript()
+            assert "MATLAB from Python" in text
+            assert "matlabengine" in text
+            assert "how to call matlab from python" in text
+
+    _run(scenario())


### PR DESCRIPTION
## Summary

Implements the long-promised Terminal UI (the `tui` optional extra). A [Textual](https://textual.textualize.io/)-based interactive app that sits on top of the existing `db` + `search` layer — no new state of its own.

Launch with `ricoeur tui` (after `uv sync --extra tui`).

## What it does

- **Browse** — opens to your most recent conversations.
- **Search** — type a query, press Enter for instant keyword (FTS5) search; clear the box and press Enter to return to the recent list.
- **Read** — select a row to open the full conversation, rendered as Markdown (role headers, code blocks, etc.).

| Key | Action |
|-----|--------|
| `/` | Focus search |
| `Enter` | Search (in box) / open conversation (in list) |
| `↑ ↓ j k` | Move / scroll |
| `Esc` | Back |
| `q` | Quit |

## Robustness

- Missing database → friendly CLI message pointing to `ricoeur init` (no stack trace).
- Initialized but empty DB → empty-state status line instead of a crash.

## Tests

- 6 headless pilot tests (`tests/test_tui.py`, skipped if `textual` isn't installed): mount/recent, keyword search filtering, no-match, empty-query reset, open/back navigation, and transcript content.
- Full suite: **53 passed**.

## Notes

- Keyword search is the default in the TUI (instant, no embedding model load); the underlying `search_dispatch` is reused so semantic/hybrid can be layered on later.
- Implementation gotcha worth flagging: a widget method named `_render` shadows Textual's internal `Widget._render()` and corrupts rendering — renamed to `_transcript`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)